### PR TITLE
Cutting off the survey solution at 5 minutes

### DIFF
--- a/dorado/scheduling/scripts/survey.py
+++ b/dorado/scheduling/scripts/survey.py
@@ -84,6 +84,7 @@ def main(args=None):
 
     log.info('generating model')
     m = Model()
+    m.set_time_limit(300)
     if args.jobs is not None:
         m.context.cplex_parameters.threads = args.jobs
 


### PR DESCRIPTION
To ensure we can get the survey scheduled in a reasonable time.