### PR TITLE
Minor cleanup in compute_overlap

### DIFF
--- a/dorado/scheduling/scripts/simsurvey.py
+++ b/dorado/scheduling/scripts/simsurvey.py
@@ -219,10 +219,8 @@ def main(args=None):
             continue
 
         if survey == "galactic_plane":
-            idx = np.where(np.abs(coords.galactic.b.deg) <= 15.0)[0]
-            n = 0.01 * np.ones(npix)
-            n[idx] = 1.0
-            prob = n / np.sum(n)
+            prob = (np.abs(coords.galactic.b.deg) <= 15.0)
+            prob = prob / prob.sum()
 
             prob = get_observed(start_time, survey_model, schedulenames, prob)
             if args.doDust:

--- a/dorado/scheduling/scripts/simsurvey.py
+++ b/dorado/scheduling/scripts/simsurvey.py
@@ -227,7 +227,7 @@ def main(args=None):
                 prob = prob*V
 
         elif survey == "kilonova":
-            n = 0.01 * np.ones(npix)
+            n = 0.01 * np.ones(survey_model.healpix.npix)
 
             tindex = int(quadlen/2)
             tquad = quad.loc[tindex]

--- a/dorado/scheduling/scripts/simsurvey.py
+++ b/dorado/scheduling/scripts/simsurvey.py
@@ -243,14 +243,15 @@ def main(args=None):
             idx = int(np.floor(10*np.random.rand()))
             gwskymap = 'GW/%d.fits' % idx
             skymap = read_sky_map(gwskymap, moc=True)['UNIQ', 'PROBDENSITY']
-            prob = rasterize(skymap, nside_to_level(nside))['PROB']
+            prob = rasterize(
+                skymap, nside_to_level(survey_model.healpix.nside))['PROB']
             prob = prob[survey_model.healpix.ring_to_nested(np.arange(
                                                             len(prob)))]
             if args.doDust:
                 prob = prob*V
 
         elif survey == "baseline":
-            n = 0.01 * np.ones(npix)
+            n = 0.01 * np.ones(survey_model.healpix.npix)
 
             tquad = quad.loc[tind]
             raquad, decquad = tquad["center"].ra, tquad["center"].dec
@@ -308,7 +309,7 @@ def main(args=None):
 
     scheduleall.write(schedulename, format='ascii.ecsv')
 
-    n = np.ones((npix,))
+    n = np.ones(survey_model.healpix.npix)
     prob = n / np.sum(n)
     write_sky_map(skymapname, prob, moc=True, gps_time=start_time.gps)
 


### PR DESCRIPTION
This removes Healpy from the script and uses the high-level astropy-healpix API instead.

I don't understand what the `compute_overlap` function does. It looks like it is computing the area of largest overlap between the first 100 tiles and the rest of the tiles. However, it is multiply the number of pixels in the overlap by the pixel linear resolution in arc minutes, which does not make any dimensional sense. The number of pixels in the overlap is a measure of area.