### PR TITLE
Add unit test for sky grid module

### DIFF
--- a/dorado/scheduling/skygrid/_sinusoidal.py
+++ b/dorado/scheduling/skygrid/_sinusoidal.py
@@ -34,14 +34,14 @@ def sinusoidal(area):
 
     """
     # Diameter of the field of view
-    diameter = 2 * np.sqrt(area.to_value(u.sr) / np.pi)
+    width = np.sqrt(area.to_value(u.sr))
 
     # Declinations of equal-declination strips
-    n_decs = int(np.ceil(np.pi / diameter)) + 1
+    n_decs = int(np.ceil(np.pi / width)) + 1
     decs = np.linspace(-0.5 * np.pi, 0.5 * np.pi, n_decs)
 
     # Number of RA steps in each equal-declination strip
-    n_ras = np.ceil(2 * np.pi * np.cos(decs) / diameter).astype(int)
+    n_ras = np.ceil(2 * np.pi * np.cos(decs) / width).astype(int)
     n_ras = np.maximum(1, n_ras)
 
     ras = np.concatenate([np.linspace(0, 2 * np.pi, n, endpoint=False)

--- a/dorado/scheduling/tests/test_skygrid.py
+++ b/dorado/scheduling/tests/test_skygrid.py
@@ -1,0 +1,31 @@
+#
+# Copyright © 2020 United States Government as represented by the Administrator
+# of the National Aeronautics and Space Administration. No copyright is claimed
+# in the United States under Title 17, U.S. Code. All Other Rights Reserved.
+#
+# SPDX-License-Identifier: NASA-1.3
+#
+from functools import partial
+
+from astropy import units as u
+import pytest
+
+from .. import skygrid
+
+
+geodesic_methods = [
+    partial(skygrid.geodesic, base=base, class_=class_)
+    for base in ['icosahedron', 'octahedron', 'tetrahedron']
+    for class_ in ['I', 'II', 'III']]
+
+
+@pytest.mark.parametrize('method', [
+    *geodesic_methods,
+    skygrid.golden_angle_spiral,
+    skygrid.healpix,
+    skygrid.sinusoidal
+])
+@pytest.mark.parametrize('area', [10, 100, 1000] * u.deg**2)
+def test_skygrid(method, area):
+    coords = method(area)
+    assert len(coords) >= (u.spat / area)


### PR DESCRIPTION
Also, fix conversion of area to linear scale in sinusoidal grid method. The new test_skygrid unit test fails without this.

Where was the factor of 2/pi from, @mcoughlin? Is this a bug in `sinusoidal`, or a bug in the new test?