### PR TITLE
Fill gaps in sinusoidal tiling near poles

### DIFF
--- a/dorado/scheduling/skygrid/_sinusoidal.py
+++ b/dorado/scheduling/skygrid/_sinusoidal.py
@@ -14,7 +14,8 @@ def sinusoidal(area):
     """Generate a uniform grid on a sinusoidal equal area projection.
 
     This is similar to what was used for GRANDMA follow-up in LIGO/Virgo
-    Observing Run 3 (O3). See :doi:`10.3847/2041-8213/ab3399`.
+    Observing Run 3 (O3), but is more efficient at tiling the poles.
+    See :doi:`10.3847/2041-8213/ab3399`.
 
     Parameters
     ----------
@@ -39,10 +40,12 @@ def sinusoidal(area):
     # Declinations of equal-declination strips
     n_decs = int(np.ceil(np.pi / width)) + 1
     decs = np.linspace(-0.5 * np.pi, 0.5 * np.pi, n_decs)
+    d_dec = decs[1] - decs[0]
 
     # Number of RA steps in each equal-declination strip
-    n_ras = np.ceil(2 * np.pi * np.cos(decs) / width).astype(int)
-    n_ras = np.maximum(1, n_ras)
+    decs_edge = decs - 0.5 * d_dec * np.where(decs >= 0, 1, -1)
+    n_ras = np.ceil(2 * np.pi * np.cos(decs_edge) / width).astype(int)
+    n_ras[0] = n_ras[-1] = 1
 
     ras = np.concatenate([np.linspace(0, 2 * np.pi, n, endpoint=False)
                           for n in n_ras])


### PR DESCRIPTION
Instead of calculating the number of tiles in a given ring from its central declination, use the declination of the edge of the ring that is closest to the equator.

This dramatically improves tiling efficiency near the poles.

Here is an example from https://dorado-scheduling.readthedocs.io/en/latest/examples/plot_skygrid.html.

| Before | After |
| - | - |
| ![sphx_glr_plot_skygrid_001](https://user-images.githubusercontent.com/728407/117072189-1346a680-acfe-11eb-9455-f4554e1dcaa5.png) | ![sphx_glr_plot_skygrid_001-2](https://user-images.githubusercontent.com/728407/117072226-1d68a500-acfe-11eb-9578-836efa685cea.png) |
| ![sphx_glr_plot_skygrid_003](https://user-images.githubusercontent.com/728407/117072065-ebefd980-acfd-11eb-898f-ebdb63f3af0b.png) | ![sphx_glr_plot_skygrid_003-2](https://user-images.githubusercontent.com/728407/117072135-03c75d80-acfe-11eb-8861-76448796441c.png) |


